### PR TITLE
chore(ci): integrate ruleset workflow to auto-protect new repos

### DIFF
--- a/.github/workflows/apply-ruleset.yml
+++ b/.github/workflows/apply-ruleset.yml
@@ -1,0 +1,32 @@
+name: Apply Branch RuleSet (Admin)
+
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        required: true
+        description: 'Repository owner or org'
+      repo:
+        required: true
+        description: 'Repository name'
+      status_check:
+        required: false
+        description: 'Exact status check name, e.g. "Android CI / Build · Unit tests · Lint"'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout admin repo
+        uses: actions/checkout@v4
+
+      - name: Run apply_ruleset script
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}
+        run: |
+          chmod +x ./scripts/apply_ruleset.sh
+          ./scripts/apply_ruleset.sh "${{ github.event.inputs.owner }}" "${{ github.event.inputs.repo }}" "${{ github.event.inputs.status_check }}"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,135 @@
+DESCRIPTION
+
+Automates applying branch protection rulesets to newly created repositories — bootstraps secure defaults (require PRs, CI status checks, block force-pushes, prevent deletions).
+
+---
+
+# Admin Tools — Ruleset Automation
+
+This repository contains admin tooling and a GitHub Action to automate creation and application of branch protection rulesets for newly created repositories. It bootstraps repos with a secure default posture so teams can ship safely and consistently.
+
+> Purpose: make new repositories safe by default (require PRs, require CI checks, block destructive pushes) — a small but high-impact step toward production-grade engineering.
+
+## Features
+
+- **Protect the `main` branch**
+    - Applies to `refs/heads/main`.
+    - Prevents accidental force pushes and branch deletion.
+
+- **Require a pull request before merging**
+    - At least one approving review required.
+    - **Dismiss stale pull request approvals** when new commits are pushed.
+    - **Require review from Code Owners** (if `.github/CODEOWNERS` is defined).
+    - Block direct pushes; enforce merges via PR only.
+
+- **Require status checks to pass before merging**
+    - Optionally specify one or more required CI checks (e.g., `Android CI / Build · Unit tests · Lint`).
+    - Strict mode: branch must be up-to-date with `main` before merging.
+
+- **Enforce for administrators**
+    - Admins are not exempt from rules (no silent bypass).
+
+- **Security hardening**
+    - Block force-pushes (`git push --force`) to preserve history.
+    - Prevent deletion of the protected branch.
+
+- **Automation options**
+    - Run locally with a GitHub personal access token (PAT) or `gh auth`.
+    - Run automatically from a secure admin GitHub Action (`workflow_dispatch`).
+
+## Repository layout
+
+```
+repo-root/
+├─ .github/
+│  └─ workflows/
+│     └─ apply-ruleset.yml         # admin workflow (workflow_dispatch)
+├─ scripts/
+│  └─ apply_ruleset.sh            # script that calls GitHub API to create ruleset
+├─ README.md                      # this file
+```
+
+## Quick start — Local run
+
+1. Generate a **fine-grained** Personal Access Token (PAT) with minimal permissions (see next section). Copy it now.
+2. Save `apply_ruleset.sh` locally and make it executable:
+
+```bash
+chmod +x scripts/apply_ruleset.sh
+```
+
+3. Export the PAT into your shell session (temporary):
+
+```bash
+export ADMIN_PAT="ghp_xxx..." # paste your fine-grained token here
+export GITHUB_TOKEN="$ADMIN_PAT"  # script expects GITHUB_TOKEN variable
+```
+
+4. Run the script with parameters: `OWNER` `REPO` and the exact status check name (copy from PR checks UI):
+
+```bash
+./scripts/apply_ruleset.sh karthik-pro-engr architecting-state "Android CI / Build · Unit tests · Lint"
+```
+
+5. When finished, unset the token from your shell:
+
+```bash
+unset GITHUB_TOKEN
+unset ADMIN_PAT
+```
+
+## Quick start — Run from GitHub (Admin repo)
+
+1. Create this admin repo (private recommended) and add `scripts/apply_ruleset.sh` and `.github/workflows/apply-ruleset.yml`.
+2. Generate a fine-grained PAT and add it to the admin repo secrets as `ADMIN_PAT`.
+3. In the Actions tab, select **Apply Branch Ruleset (Admin)** → **Run workflow** and provide:
+   - `owner`: repository owner (user or org)
+   - `repo`: repository name
+   - `status_check`: exact status check name (optional; can be added later)
+
+The workflow will run the script using the secret token and apply the ruleset.
+
+## Fine-grained PAT: minimal permission checklist
+
+When creating the token, follow these minimal permissions for safety:
+- Resource owner: your user/org
+- Repository access: **Only select repositories** → add the target repo(s)
+- Permissions:
+  - **Repository → Administration**: Read & write (needed to create rulesets)
+  - **Checks**: Read & write (if the script will reference checks)
+  - (Optional) **Contents → Read** if script needs to inspect repo files
+- Set a reasonable expiration; rotate tokens regularly.
+
+> If possible for long-term automation, prefer a GitHub App (installable) instead of a PAT.
+
+## How the script behaves
+
+- If you provide a `status_check` string it will be placed into `required_status_checks` for the ruleset.
+- If you omit `status_check` the script creates the ruleset with an empty checks array — update it later after the CI check has run once and you know the exact name.
+- The script will enable: pull request requirement, required status checks (strict), require 1 approving review, enforce admins, block force pushes, and prevent branch deletions. Customize in `scripts/apply_ruleset.sh` as needed.
+
+## Security & operational notes
+
+- Keep this repo **private** or strictly limit who can run workflows.
+- Protect branches in this admin repo (require PRs, reviews) so its workflows/secrets aren’t abused.
+- Use least privilege for tokens; rotate tokens periodically.
+- Test the flow in a sandbox repo before running in production.
+
+## Example: Update ruleset after CI shows check names
+
+1. Create or update a PR in the target repo so CI runs at least once.
+2. Copy the exact check title shown on the PR checks UI.
+3. Re-run the script (local or admin workflow) supplying that check title to make it required.
+
+## Troubleshooting
+
+- **403 / Permission denied**: token lacks repo administration rights or is not scoped to the target repo. Recreate token with correct permissions and re-run.
+- **Status check not selectable**: the check must have run at least once on the repo/PR before you can require it in the ruleset. Run CI first and then update ruleset.
+
+## License & contribution
+
+This admin-tooling is provided "as-is". If you plan to share or use in an organization, consider adding a LICENSE and internal documentation for token rotation and audit procedures.
+
+---
+
+

--- a/scripts/apply_ruleset.sh
+++ b/scripts/apply_ruleset.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   GITHUB_TOKEN must be set as env var (or use gh auth)
+#   ./apply_ruleset.sh <owner> <repo> "<status_check_name>"
+#
+# Example:
+#   ./apply_ruleset.sh karthik-pro-engr architecting-state "Android CI / Build · Unit tests · Lint"
+
+OWNER="$1"
+REPO="$2"
+STATUS_CHECK_NAME="${3-}"  # e.g. "Android CI / Build · Unit tests · Lint"
+API="https://api.github.com/repos/${OWNER}/${REPO}/rulesets"
+
+if [ -z "${GITHUB_TOKEN-}" ] && ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: Set GITHUB_TOKEN environment variable or run 'gh auth login' first."
+  exit 1
+fi
+
+echo "Creating branch ruleset 'protect-main' on ${OWNER}/${REPO} (target: refs/heads/main)"
+
+# Compose checks array: if user supplied a name, include it. Otherwise leave empty (you can update later).
+CHECKS_JSON="[]"
+if [ -n "${STATUS_CHECK_NAME}" ]; then
+  CHECKS_JSON="[ { \"name\": \"${STATUS_CHECK_NAME//\"/\\\"}\" } ]"
+fi
+
+# Note: this rule set will:
+#  - require pull requests
+#  - require the provided status check(s) (if provided)
+#  - require 1 approving review
+#  - dismiss stale approvals when new commits are pushed
+#  - require code owner reviews (if a CODEOWNERS file exists)
+#  - enforce admins, block force pushes and prevent deletions
+#
+# Important: For "Require review from Code Owners" to take effect, make sure a
+# CODEOWNERS file exists on the base branch (usually main). If not present,
+# the rule will still be created but code-owner reviews won't be enforced.
+
+read -r -d '' PAYLOAD <<EOF
+{
+  "name":"protect-main",
+  "target":"branch",
+  "enforcement":"active",
+  "conditions": {
+    "ref_name": { "include": ["refs/heads/main"] }
+  },
+  "bypass_actors": [],
+  "rules": [
+    { "type": "pull_request_required", "parameters": {} },
+    { "type": "required_status_checks", "parameters": { "checks": ${CHECKS_JSON}, "strict": true } },
+    {
+      "type": "require_approving_review_count",
+      "parameters": {
+        "count": 1,
+        "dismiss_stale_reviews": true,
+        "require_code_owner_reviews": true
+      }
+    },
+    { "type": "enforce_admins", "parameters": { "enabled": true } },
+    { "type": "block_force_pushes", "parameters": { "enabled": true } },
+    { "type": "prevent_deletions", "parameters": { "enabled": true } }
+  ]
+}
+EOF
+
+# Use GITHUB_TOKEN if available, otherwise use gh api
+if [ -n "${GITHUB_TOKEN-}" ]; then
+  curl -sS -X POST \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "${API}" -d "${PAYLOAD}" | jq .
+else
+  echo "${PAYLOAD}" > /tmp/payload.json
+  gh api "${API}" -X POST -f /tmp/payload.json | jq .
+fi
+
+echo "Ruleset creation API called. If you included a status check name, ensure it matches exactly the check name shown on PRs."


### PR DESCRIPTION
Add an admin workflow and helper script to create and apply branch protection rulesets for newly created repositories.

- .github/workflows/apply-ruleset.yml: workflow_dispatch admin workflow to run the ruleset-apply script.
- scripts/apply_ruleset.sh: calls GitHub Rulesets API to create a 'protect-main' ruleset (requires PRs, optional status checks, dismiss stale approvals, require CODEOWNERS, block force-pushes, prevent deletions).
- README / docs: usage, token permission guidance, and security notes.

This bootstraps new repos with safe defaults so teams ship with confidence. Useful for repo hygiene and org-level automation — helps move toward the professional workflows expected at the 1 Crore job level.